### PR TITLE
Fix cleanup logic in rate limiter

### DIFF
--- a/src/utils/__tests__/rate-limit.test.js
+++ b/src/utils/__tests__/rate-limit.test.js
@@ -48,8 +48,22 @@ describe('RateLimiter', () => {
   test('should calculate remaining time correctly', () => {
     rateLimiter.isRateLimited(userId);
     const remainingTime = rateLimiter.getRemainingTime(userId);
-    
+
     expect(remainingTime).toBeGreaterThan(0);
     expect(remainingTime).toBeLessThanOrEqual(100);
+  });
+
+  test('should clean expired requests after limit is reached', async () => {
+    // Hit the limit
+    expect(rateLimiter.isRateLimited(userId)).toBe(false);
+    expect(rateLimiter.isRateLimited(userId)).toBe(false);
+    expect(rateLimiter.isRateLimited(userId)).toBe(true);
+
+    // Wait for the time window to pass
+    await new Promise((resolve) => setTimeout(resolve, 100));
+
+    // Remaining time should be zero once requests have expired
+    expect(rateLimiter.getRemainingTime(userId)).toBe(0);
+    expect(rateLimiter.isRateLimited(userId)).toBe(false);
   });
 });

--- a/src/utils/rate-limit.js
+++ b/src/utils/rate-limit.js
@@ -8,11 +8,14 @@ class RateLimiter {
   isRateLimited(userId) {
     const now = Date.now();
     const userRequests = this.requests.get(userId) || [];
-    
+
     // Remove old requests outside the time window
-    const validRequests = userRequests.filter(timestamp => 
-      now - timestamp < this.timeWindowMs
+    const validRequests = userRequests.filter(
+      (timestamp) => now - timestamp < this.timeWindowMs
     );
+
+    // Update stored requests with cleaned list
+    this.requests.set(userId, validRequests);
 
     // Check if user has exceeded rate limit
     if (validRequests.length >= this.maxRequests) {
@@ -26,11 +29,19 @@ class RateLimiter {
   }
 
   getRemainingTime(userId) {
+    const now = Date.now();
     const userRequests = this.requests.get(userId) || [];
-    if (userRequests.length === 0) return 0;
 
-    const oldestRequest = userRequests[0];
-    const timeUntilReset = this.timeWindowMs - (Date.now() - oldestRequest);
+    // Remove outdated requests and update store
+    const validRequests = userRequests.filter(
+      (timestamp) => now - timestamp < this.timeWindowMs
+    );
+    this.requests.set(userId, validRequests);
+
+    if (validRequests.length === 0) return 0;
+
+    const oldestRequest = validRequests[0];
+    const timeUntilReset = this.timeWindowMs - (now - oldestRequest);
     return Math.max(0, timeUntilReset);
   }
 }


### PR DESCRIPTION
## Summary
- fix `RateLimiter` so it always removes outdated requests
- update `getRemainingTime` accordingly
- extend rate limiter tests to verify cleanup

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_683f83cdfcd883249fa43a06b490e848