### PR TITLE
Fix comment in middleware

### DIFF
--- a/src/slack/middleware.js
+++ b/src/slack/middleware.js
@@ -11,7 +11,7 @@ const errorHandler = async ({ error, logger }) => {
 };
 
 const logMiddleware = async ({ logger, context, next }) => {
-  // Add timestamp to the context
+  // Record start time for logging
   const startTime = new Date().getTime();
   
   // Continue processing the request


### PR DESCRIPTION
## Summary
- correct the description of timestamp handling in `logMiddleware`

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_683f85dbdfdc83249208d848382bb88b