### PR TITLE
Fix searchTickets context and add test for domain in URLs

### DIFF
--- a/src/__tests__/zendesk.test.js
+++ b/src/__tests__/zendesk.test.js
@@ -1,0 +1,31 @@
+const ZendeskClient = require('../zendesk');
+
+describe('ZendeskClient', () => {
+  describe('searchTickets', () => {
+    test('should include correct domain in ticket URLs', async () => {
+      const client = new ZendeskClient('example.zendesk.com', 'user@example.com', 'token');
+
+      // Mock makeRequest to return a fake search response
+      client.makeRequest = jest.fn().mockResolvedValue({
+        results: [
+          {
+            id: 123,
+            subject: 'Test',
+            description: 'Desc',
+            status: 'open',
+            priority: 'normal',
+            requester_id: 1,
+            assignee_id: 2,
+            created_at: '2024-01-01T00:00:00Z',
+            updated_at: '2024-01-02T00:00:00Z',
+            tags: ['sample']
+          }
+        ],
+        count: 1
+      });
+
+      const { results } = await client.searchTickets('test');
+      expect(results[0].url).toBe('https://example.zendesk.com/agent/tickets/123');
+    });
+  });
+});

--- a/src/zendesk.js
+++ b/src/zendesk.js
@@ -55,7 +55,7 @@ class ZendeskClient {
     );
     
     return {
-      results: response.results.map(this.formatTicketResponse),
+      results: response.results.map(ticket => this.formatTicketResponse(ticket)),
       count: response.count
     };
   }


### PR DESCRIPTION
## Summary
- fix `searchTickets` to call `formatTicketResponse` with the correct `this`
- add tests covering `searchTickets` URL domain

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_683f85d8f32c8324971b1d8d71962f29