### PR TITLE
Add tests for remaining time reset

### DIFF
--- a/src/utils/__tests__/rate-limit.test.js
+++ b/src/utils/__tests__/rate-limit.test.js
@@ -48,8 +48,19 @@ describe('RateLimiter', () => {
   test('should calculate remaining time correctly', () => {
     rateLimiter.isRateLimited(userId);
     const remainingTime = rateLimiter.getRemainingTime(userId);
-    
+
     expect(remainingTime).toBeGreaterThan(0);
     expect(remainingTime).toBeLessThanOrEqual(100);
+  });
+
+  test('should return 0 remaining time with no requests or after window', async () => {
+    // No requests made yet
+    expect(rateLimiter.getRemainingTime(userId)).toBe(0);
+
+    // Make a request and wait for the window to expire
+    rateLimiter.isRateLimited(userId);
+    await new Promise(resolve => setTimeout(resolve, 100));
+
+    expect(rateLimiter.getRemainingTime(userId)).toBe(0);
   });
 });

--- a/src/utils/__tests__/rate-limit.test.js
+++ b/src/utils/__tests__/rate-limit.test.js
@@ -53,6 +53,20 @@ describe('RateLimiter', () => {
     expect(remainingTime).toBeLessThanOrEqual(100);
   });
 
+  test('should clean expired requests after limit is reached', async () => {
+    // Hit the limit
+    expect(rateLimiter.isRateLimited(userId)).toBe(false);
+    expect(rateLimiter.isRateLimited(userId)).toBe(false);
+    expect(rateLimiter.isRateLimited(userId)).toBe(true);
+
+    // Wait for the time window to pass
+    await new Promise((resolve) => setTimeout(resolve, 100));
+
+    // Remaining time should be zero once requests have expired
+    expect(rateLimiter.getRemainingTime(userId)).toBe(0);
+    expect(rateLimiter.isRateLimited(userId)).toBe(false);
+  });
+
   test('should return 0 remaining time with no requests or after window', async () => {
     // No requests made yet
     expect(rateLimiter.getRemainingTime(userId)).toBe(0);


### PR DESCRIPTION
## Summary
- add unit test verifying `getRemainingTime` returns `0` when no requests were made or after the time window elapses

## Testing
- `npm test --silent` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_683f85de27c48324b594ad2836587f33