### PR TITLE
Handle Zendesk 404 errors

### DIFF
--- a/src/__tests__/zendesk.test.js
+++ b/src/__tests__/zendesk.test.js
@@ -28,4 +28,17 @@ describe('ZendeskClient', () => {
       expect(results[0].url).toBe('https://example.zendesk.com/agent/tickets/123');
     });
   });
+
+  describe('getTicket', () => {
+    test('should throw a Ticket not found error on 404', async () => {
+      const client = new ZendeskClient('example.zendesk.com', 'user@example.com', 'token');
+
+      const err = new Error('Zendesk API Error: Not Found');
+      err.status = 404;
+
+      client.makeRequest = jest.fn().mockRejectedValue(err);
+
+      await expect(client.getTicket(123)).rejects.toThrow('Ticket not found');
+    });
+  });
 });

--- a/src/zendesk.js
+++ b/src/zendesk.js
@@ -26,7 +26,11 @@ class ZendeskClient {
 
       if (!response.ok) {
         const error = await response.json().catch(() => ({ error: response.statusText }));
-        throw new Error(`Zendesk API Error: ${error.error || response.statusText}`);
+        const err = new Error(
+          `Zendesk API Error: ${error.error || response.statusText}`
+        );
+        err.status = response.status;
+        throw err;
       }
 
       return await response.json();
@@ -41,8 +45,8 @@ class ZendeskClient {
       const { ticket } = await this.makeRequest(`/tickets/${ticketId}.json`);
       return this.formatTicketResponse(ticket);
     } catch (error) {
-      if (error.message.includes('404')) {
-        throw new Error(`Ticket ${ticketId} not found`);
+      if (error.status === 404) {
+        throw new Error('Ticket not found');
       }
       throw error;
     }


### PR DESCRIPTION
## Summary
- propagate response status in Zendesk client errors
- return a specific `Ticket not found` message when a ticket is missing
- test that a 404 response triggers the custom error

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_683f8f886a308324aa961366a4b85f17