### PR TITLE
Add input validation in Slack commands

### DIFF
--- a/src/slack/__tests__/commands.test.js
+++ b/src/slack/__tests__/commands.test.js
@@ -1,0 +1,37 @@
+const { ticketDetails, ticketSummary, searchTickets } = require('../commands');
+const { formatErrorMessage } = require('../../utils/validation');
+
+describe('Slack Command Validation', () => {
+  test('ticketDetails responds with error on invalid ticket ID', async () => {
+    const ack = jest.fn();
+    const respond = jest.fn();
+    await ticketDetails({ command: { text: 'abc' }, ack, respond });
+    expect(ack).toHaveBeenCalled();
+    expect(respond).toHaveBeenCalledWith(
+      formatErrorMessage('Invalid ticket ID', 'ticket-details')
+    );
+  });
+
+  test('ticketSummary responds with error on invalid ticket ID', async () => {
+    const ack = jest.fn();
+    const respond = jest.fn();
+    await ticketSummary({ command: { text: '' }, ack, respond });
+    expect(ack).toHaveBeenCalled();
+    expect(respond).toHaveBeenCalledWith(
+      formatErrorMessage('Invalid ticket ID', 'ticket-summary')
+    );
+  });
+
+  test('searchTickets responds with error on invalid query', async () => {
+    const ack = jest.fn();
+    const respond = jest.fn();
+    await searchTickets({ command: { text: 'a' }, ack, respond });
+    expect(ack).toHaveBeenCalled();
+    expect(respond).toHaveBeenCalledWith(
+      formatErrorMessage(
+        'Search query must be at least 2 characters long',
+        'search-tickets'
+      )
+    );
+  });
+});


### PR DESCRIPTION
## Summary
- use shared validation helpers in `src/slack/commands.js`
- add unit tests for invalid command inputs

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_683f8fc0ac848324beaf5b82db5aaa13