### PR TITLE
Add tests for OpenAI client

### DIFF
--- a/src/__tests__/openai.test.js
+++ b/src/__tests__/openai.test.js
@@ -1,0 +1,76 @@
+const createMock = jest.fn();
+
+jest.mock('openai', () => ({ OpenAI: jest.fn() }));
+
+const { OpenAI } = require('openai');
+const OpenAIClient = require('../openai');
+
+describe('OpenAIClient', () => {
+  beforeEach(() => {
+    createMock.mockReset();
+    OpenAI.mockImplementation(() => ({
+      chat: { completions: { create: createMock } }
+    }));
+  });
+
+  describe('summarizeTicket', () => {
+    test('returns summary from OpenAI response', async () => {
+      const expected = 'A short summary.';
+      createMock.mockResolvedValue({
+        choices: [{ message: { content: expected } }]
+      });
+
+      const client = new OpenAIClient('fake-key');
+      const ticket = { id: 1, subject: 'Bug', status: 'open', priority: 'high', description: 'Details' };
+
+      const summary = await client.summarizeTicket(ticket, []);
+      expect(createMock).toHaveBeenCalled();
+      expect(summary).toBe(expected);
+    });
+  });
+
+  describe('prepareConversationHistory', () => {
+    test('formats ticket and comments into history', () => {
+      const client = new OpenAIClient('fake-key');
+      const ticket = {
+        id: 1,
+        subject: 'Bug report',
+        status: 'open',
+        priority: 'high',
+        description: 'Something is broken'
+      };
+      const comments = [
+        { author: 'Alice', body: 'First comment', public: true },
+        { author: 'Bob', body: 'Private comment', public: false },
+        { author: 'Charlie', body: 'Another comment', public: true }
+      ];
+
+      const history = client.prepareConversationHistory(ticket, comments);
+
+      expect(history).toContain('TICKET #1: Bug report');
+      expect(history).toContain('Status: open');
+      expect(history).toContain('Priority: high');
+      expect(history).toContain('Initial Description:\nSomething is broken');
+      expect(history).toContain('Conversation:');
+      expect(history).toContain('From: Alice');
+      expect(history).toContain('First comment');
+      expect(history).toContain('From: Charlie');
+      expect(history).toContain('Another comment');
+      expect(history).not.toContain('Private comment');
+    });
+  });
+
+  describe('generateSummaryBlocks', () => {
+    test('produces Slack blocks with ticket information', async () => {
+      const client = new OpenAIClient('fake-key');
+      const ticket = { id: 42, subject: 'Important bug', url: 'https://example.com/tickets/42' };
+      const blocks = await client.generateSummaryBlocks(ticket, 'Summary here');
+
+      expect(Array.isArray(blocks)).toBe(true);
+      expect(blocks[0].text.text).toBe('📝 Summary of Ticket #42');
+      expect(blocks[1].text.text).toBe('*Original Subject:* Important bug');
+      expect(blocks[3].text.text).toBe('Summary here');
+      expect(blocks[4].elements[0].text).toContain(`<${ticket.url}|View the full ticket in Zendesk>`);
+    });
+  });
+});

--- a/src/slack/__tests__/commands.test.js
+++ b/src/slack/__tests__/commands.test.js
@@ -1,3 +1,4 @@
+process.env.OPENAI_API_KEY = 'test';
 const { ticketDetails, ticketSummary, searchTickets } = require('../commands');
 const { formatErrorMessage } = require('../../utils/validation');
 


### PR DESCRIPTION
## Summary
- test OpenAI helper functions
- mock the OpenAI package to avoid real API calls
- set `OPENAI_API_KEY` in command tests so OpenAIClient can be instantiated

## Testing
- `npm test --silent`
- `npm run test:coverage --silent`


------
https://chatgpt.com/codex/tasks/task_e_683f91d88da48324887f431b72b42dc1