### PR TITLE
Fix rate limit cleanup

### DIFF
--- a/src/utils/__tests__/rate-limit.test.js
+++ b/src/utils/__tests__/rate-limit.test.js
@@ -79,4 +79,12 @@ describe('RateLimiter', () => {
     expect(rateLimiter.getRemainingTime(userId)).toBe(0);
   });
 
+  test('removes user entry after all requests expire', async () => {
+    rateLimiter.isRateLimited(userId);
+    await new Promise(resolve => setTimeout(resolve, 100));
+    // Trigger cleanup
+    rateLimiter.getRemainingTime(userId);
+    expect(rateLimiter.requests.has(userId)).toBe(false);
+  });
+
 });

--- a/src/utils/rate-limit.js
+++ b/src/utils/rate-limit.js
@@ -14,8 +14,12 @@ class RateLimiter {
       (timestamp) => now - timestamp < this.timeWindowMs
     );
 
-    // Update stored requests with cleaned list
-    this.requests.set(userId, validRequests);
+    // Update stored requests with cleaned list or delete if none left
+    if (validRequests.length === 0) {
+      this.requests.delete(userId);
+    } else {
+      this.requests.set(userId, validRequests);
+    }
 
     // Check if user has exceeded rate limit
     if (validRequests.length >= this.maxRequests) {
@@ -36,9 +40,14 @@ class RateLimiter {
     const validRequests = userRequests.filter(
       (timestamp) => now - timestamp < this.timeWindowMs
     );
+
+    if (validRequests.length === 0) {
+      this.requests.delete(userId);
+      return 0;
+    }
+
     this.requests.set(userId, validRequests);
 
-    if (validRequests.length === 0) return 0;
 
     const oldestRequest = validRequests[0];
     const timeUntilReset = this.timeWindowMs - (now - oldestRequest);


### PR DESCRIPTION
## Summary
- remove user entries when their request history expires
- test cleanup logic for rate limit requests

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_683f99989a808324b634dfecdfcea994