### PR TITLE
Allow configurable OpenAI model

### DIFF
--- a/.env.template
+++ b/.env.template
@@ -9,6 +9,7 @@ ZENDESK_API_TOKEN=your-api-token
 
 # OpenAI Configuration
 OPENAI_API_KEY=your-openai-api-key
+OPENAI_MODEL=
 
 # Server Configuration
 PORT=3000

--- a/README.md
+++ b/README.md
@@ -41,12 +41,13 @@ A powerful Slack bot that integrates with Zendesk for ticket management and prov
    ```
    SLACK_BOT_TOKEN=xoxb-your-token
    SLACK_SIGNING_SECRET=your-signing-secret
-   ZENDESK_DOMAIN=your-subdomain.zendesk.com
-   ZENDESK_EMAIL=your-email
-   ZENDESK_API_TOKEN=your-api-token
-   OPENAI_API_KEY=your-openai-api-key
-   PORT=3000
-   ```
+    ZENDESK_DOMAIN=your-subdomain.zendesk.com
+    ZENDESK_EMAIL=your-email
+    ZENDESK_API_TOKEN=your-api-token
+    OPENAI_API_KEY=your-openai-api-key
+    OPENAI_MODEL=
+    PORT=3000
+    ```
 
 ## Development
 

--- a/src/__tests__/openai.test.js
+++ b/src/__tests__/openai.test.js
@@ -8,6 +8,7 @@ const { MAX_HISTORY_LENGTH } = OpenAIClient;
 
 describe('OpenAIClient', () => {
   beforeEach(() => {
+    delete process.env.OPENAI_MODEL;
     createMock.mockReset();
     OpenAI.mockImplementation(() => ({
       chat: { completions: { create: createMock } }
@@ -21,11 +22,12 @@ describe('OpenAIClient', () => {
         choices: [{ message: { content: expected } }]
       });
 
+      process.env.OPENAI_MODEL = 'test-model';
       const client = new OpenAIClient('fake-key');
       const ticket = { id: 1, subject: 'Bug', status: 'open', priority: 'high', description: 'Details' };
 
       const summary = await client.summarizeTicket(ticket, []);
-      expect(createMock).toHaveBeenCalled();
+      expect(createMock).toHaveBeenCalledWith(expect.objectContaining({ model: 'test-model' }));
       expect(summary).toBe(expected);
     });
   });

--- a/src/openai.js
+++ b/src/openai.js
@@ -1,12 +1,16 @@
 // OpenAI client wrapper
 const { OpenAI } = require('openai');
 
+// Use configurable model with a sensible default
+const DEFAULT_MODEL = 'gpt-4-turbo-preview';
+
 // Limit the prompt size to prevent exceeding model context limits
 const MAX_HISTORY_LENGTH = 15000; // roughly a few thousand tokens
 
 class OpenAIClient {
   constructor(apiKey) {
     this.client = new OpenAI({ apiKey });
+    this.model = process.env.OPENAI_MODEL || DEFAULT_MODEL;
   }
 
   async summarizeTicket(ticket, comments) {
@@ -23,7 +27,7 @@ Your task is to create a clear, concise summary of the ticket conversation that 
 Keep the summary professional and focused on the most important information.`;
 
       const response = await this.client.chat.completions.create({
-        model: "gpt-4-turbo-preview",
+        model: this.model,
         messages: [
           { role: "system", content: systemPrompt },
           { 


### PR DESCRIPTION
## Summary
- let `OpenAIClient` pull the model name from `OPENAI_MODEL` with a default
- add `OPENAI_MODEL=` placeholder to `.env.template`
- document the new variable in README
- update tests for the configurable model

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_683f99a8c2f88324aad24583f3a6ca19